### PR TITLE
[FIX] Ascii meme error

### DIFF
--- a/meme_config.txt
+++ b/meme_config.txt
@@ -14,7 +14,7 @@ gingersoul; ;URL_NOT_FOUND
 theanswer; ;URL_NOT_FOUND
 licorne; ;URL_NOT_FOUND
 godwin; ;URL_NOT_FOUND
-académie; ;URL_NOT_FOUND
+academie; ;URL_NOT_FOUND
 califyes; ;URL_NOT_FOUND
 rickroll; ;URL_NOT_FOUND
 broll; ;URL_NOT_FOUND


### PR DESCRIPTION
académie -> academie

Try to fix :
"Traceback (most recent call last):

  File "/usr/local/lib/python3.5/dist-packages/discord/ext/commands/bot.py", line 846, in process_commands

    yield from command.invoke(ctx)

  File "/usr/local/lib/python3.5/dist-packages/discord/ext/commands/core.py", line 374, in invoke

    yield from injected(*ctx.args, **ctx.kwargs)

  File "/usr/local/lib/python3.5/dist-packages/discord/ext/commands/core.py", line 54, in wrapped

    raise CommandInvokeError(e) from e

discord.ext.commands.errors.CommandInvokeError: Command raised an exception: UnicodeDecodeError: 'ascii' codec can't decode byte 0xe9 in position 531: ordinal not in range(128)"